### PR TITLE
Change FAQ order by '_updatedAt' column

### DIFF
--- a/src/components/FAQ.js
+++ b/src/components/FAQ.js
@@ -7,7 +7,7 @@ import ButtonLink from './ButtonLink';
 export default function FAQ({ limit = 0, countryCode }) {
   const { faqs } = useStaticQuery(graphql`
     query {
-      faqs: allSanityFaq {
+      faqs: allSanityFaq(sort: { fields: _updatedAt, order: DESC }) {
         nodes {
           id
           question


### PR DESCRIPTION
## What column to search for:
Basically every document has its specified fields plus additional `_id`, `_createdAT`. and `_updatedAt`.

See:
> The document type is used to define the structure of a document that can be stored in our data store. You can think of a document as an object that, in addition to the fields you define, also has a unique id, (_id), a field for tracking created time and last updated time (_createdAt and _updatedAt) and a revision marker (_rev). Only documents can be referred to from other documents or retrieved by id and only document types will listed and creatable in the studio.
https://www.sanity.io/docs/document-type

## Sanity Groq vs GraphQl
Basically we use the GraphQL API of Sanity which is a bit less documented than the Sanity personal `GROQ` one (which is btw great, I use it in most of the Next.js projects now, but of course: No portability and whatsoever).

To simplify which fields are available there is the GraphQL explorer within the project.
Starting with `npm run develop` and you will get the webpage as well as:
http://localhost:8000/__graphql

## Component query
In `src/components/FAQ.js` there is the query, look for `allSanityFaq` in the explorer and you will see something similar like:
![image](https://github.com/f-online/web_static/assets/7003185/04ee907e-a0cd-40c7-9f43-42e166726d97)

Just ignore most of the stuff and look for the _updatedAt within sorting:
![image](https://github.com/f-online/web_static/assets/7003185/611038f8-5bb0-4322-bc8a-c9ec15604d2a)

The explorer will then create the query for you. Which I tend to use most often as I forget the syntax anyway.

And that's it :)

--- 

FYI @woolfg | merge if it fits your needs, or ask questions :)